### PR TITLE
Supporting nodmax and mayhem

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -62,6 +62,8 @@ if (TOOLTIP) {
       format = 'gen' + gen + 'randomdoublesbattle';
     } else if (format.includes('monotype') || format.includes('unrated')) {
       format = 'gen' + gen + 'randombattle';
+    } else if (format.includes('mayhem') || format.includes('nodmax')) {
+      format = 'gen' + gen + 'randombattlenodmax'
     }
     if (!DATA[format]) return original;
 


### PR DESCRIPTION
gen8randombattlenodmax is said to be supported in the first array but it isn't. Mayhem another popular format uses the same movepools as gen8randombattlemayhem, so support for that is requested as well.  

Scarlett/Violet is coming in less than a week though so these changes may be considered irrelevant though....