### PR TITLE
Fix PS compatibility

### DIFF
--- a/update
+++ b/update
@@ -55,15 +55,15 @@ const verify = (data, type) => {
 };
 
 const getData = (format, doubles) => format.id.startsWith('gen9')
-  ? verify(require(`./vendor/pokemon-showdown/data/random-${doubles ? 'doubles-' : ''}sets.json`),
+  ? verify(require(`./vendor/pokemon-showdown/data/random-battles/${format.mod}/${doubles ? 'doubles-' : ''}sets.json`),
     'gen9')
   : ROLES.includes(format.id) ?
-    verify(require(`./vendor/pokemon-showdown/data/mods/${format.mod}/random-sets.json`),
+    verify(require(`./vendor/pokemon-showdown/data/random-battles/${format.mod}/sets.json`),
       'roles')
     : format.id === 'gen7randomdoublesbattle' ?
       verify(require(`./vendor/pokemon-showdown/data/mods/${format.mod}/random-doubles-data.json`),
         'other')
-      : verify(require(`./vendor/pokemon-showdown/data/mods/${format.mod}/random-data.json`),
+      : verify(require(`./vendor/pokemon-showdown/data/random-battles/${format.mod}/data.json`),
         format.mod === 'gen1' ? 'gen1' : 'other');
 
 const getForme = (dex, pool, set) => {


### PR DESCRIPTION
Fixes compatibility with Pokemon Showdown after https://github.com/smogon/pokemon-showdown/pull/10285 created a separate folder for random-battles

I was able to get it to build all formats:

```text
➜  randbats git:(main) ✗ node update
[Gen 9] Random Battle: 148.562s
[Gen 9] Random Doubles Battle: 147.732s
[Gen 9] Chimera 1v1 Random Battle: 155.077s
[Gen 8] Random Battle: 50.366s
[Gen 8] Random Doubles Battle: 49.972s
[Gen 8 BDSP] Random Battle: 137.390s
[Gen 7] Random Battle: 175.817s
[Gen 7 Let's Go] Random Battle: 42.193s
[Gen 6] Random Battle: 163.999s
[Gen 5] Random Battle: 153.295s
[Gen 4] Random Battle: 145.369s
[Gen 3] Random Battle: 128.253s
[Gen 2] Random Battle: 29.850s
[Gen 1] Random Battle: 9.121s

```