### PR TITLE
Fix after megaStones become {key: value} pairs

### DIFF
--- a/update
+++ b/update
@@ -79,7 +79,7 @@ const getForme = (dex, pool, set) => {
   }
 
   const item = dex.items.get(set.item);
-  if (item.megaStone) return dex.species.get(item.megaStone);
+  if (item.megaStone) return dex.species.get(item.megaStone[set.species]);
 
   const formes = Object.keys(pool[set.species] || pool[set.name]);
   if (formes.length === 1) return dex.species.get(formes[0]);


### PR DESCRIPTION
makes compatible with: https://github.com/smogon/pokemon-showdown/commit/684150d9d7a08726bc79ead9f4a6385529f3808c

```
➜  randbats git:(main) ✗ node update      
[Gen 9] Random Battle: 62.347s
[Gen 9] Random Doubles Battle: 63.085s
[Gen 9] Baby Random Battle: 36.661s
[Gen 8] Random Battle: 45.811s
[Gen 8] Random Doubles Battle: 43.595s
[Gen 8 BDSP] Random Battle: 167.956s
[Gen 7] Random Battle: 59.347s
[Gen 7 Let's Go] Random Battle: 34.409s
[Gen 6] Random Battle: 56.151s
[Gen 5] Random Battle: 46.028s
[Gen 4] Random Battle: 41.533s
[Gen 3] Random Battle: 36.259s
[Gen 2] Random Battle: 28.990s
[Gen 1] Random Battle: 8.670s

```