### PR TITLE
Update to use new `BattleTextParser`

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -193,7 +193,7 @@ if (TOOLTIP) {
         ('ivs' in data && statName in data.ivs) || ('evs' in data && statName in data.evs);
       var statLabel = gen === 1 && statName === 'spa' ? 'spc' : statName;
       buf += statName === 'atk' ? '<small>' : '<small> / ';
-      buf += '' + BattleText[statLabel].statShortName + '&nbsp;</small>';
+      buf += '' + BattleTextParser.statShortName(statLabel) + '&nbsp;</small>';
       var italic = !known && (statName === 'atk' || statName === 'spe');
       buf += (italic ? '<i>' : '') + stats[statName] + (italic ? '</i>' : '');
     }


### PR DESCRIPTION
Makes compatible with Showdown's server and client translation update.

Relevant code: https://github.com/smogon/pokemon-showdown-client/blob/8aac6055f144600a51e4f0c29932f08399122be0/play.pokemonshowdown.com/src/battle-tooltips.ts#L1522